### PR TITLE
refactor: extract shared utilities and reduce code duplication

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './guards';
 export * from './filters';
 export * from './interfaces/openai-error.interface';
+export * from './utils';

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './schema.util';
+export * from './session.util';
+export * from './stream-parser.util';

--- a/src/common/utils/schema.util.ts
+++ b/src/common/utils/schema.util.ts
@@ -1,0 +1,32 @@
+const SCHEMA_KEYS_TO_REMOVE = [
+  '$schema',
+  'additionalProperties',
+  'strict',
+  'default',
+  'title',
+  '$id',
+  '$ref',
+];
+
+export function cleanSchemaForClaude(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const cleaned = { ...schema };
+
+  for (const key of SCHEMA_KEYS_TO_REMOVE) {
+    delete cleaned[key];
+  }
+
+  if (cleaned.properties && typeof cleaned.properties === 'object') {
+    const props = cleaned.properties as Record<string, unknown>;
+    for (const propKey of Object.keys(props)) {
+      if (typeof props[propKey] === 'object') {
+        props[propKey] = cleanSchemaForClaude(
+          props[propKey] as Record<string, unknown>,
+        );
+      }
+    }
+  }
+
+  return cleaned;
+}

--- a/src/common/utils/session.util.ts
+++ b/src/common/utils/session.util.ts
@@ -1,0 +1,4 @@
+export function generateSessionId(): string {
+  const n = BigInt(Math.floor(Math.random() * 9e18) + 1e18);
+  return `-${n.toString()}`;
+}

--- a/src/common/utils/stream-parser.util.ts
+++ b/src/common/utils/stream-parser.util.ts
@@ -1,0 +1,28 @@
+export class SSEStreamParser {
+  private buffer = '';
+
+  parseChunk(chunk: Buffer): string[] {
+    this.buffer += chunk.toString();
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() ?? '';
+
+    const dataLines: string[] = [];
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        const data = line.slice(6).trim();
+        if (data && data !== '[DONE]') {
+          dataLines.push(data);
+        }
+      }
+    }
+    return dataLines;
+  }
+
+  isDone(chunk: Buffer): boolean {
+    return chunk.toString().includes('data: [DONE]');
+  }
+
+  reset(): void {
+    this.buffer = '';
+  }
+}


### PR DESCRIPTION
## Summary
- Extract shared utilities (`cleanSchemaForClaude`, `generateSessionId`, `SSEStreamParser`) into `/src/common/utils/` to eliminate duplicate code across transformer services
- Refactor `AccountsService` to use `Map` data structures for O(1) lookups instead of O(n) array searches
- Simplify `AntigravityService` with reusable helper methods (`withAccountRetry`, `processStream`, etc.) reducing code by ~140 lines while improving maintainability

## Verification
- Build passes ✅
- All 40 tests pass ✅