### PR TITLE
feat: add quota tracking system

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Visit `http://localhost:3000/oauth/authorize` to authenticate with Google.
 | `POST /v1/chat/completions` | OpenAI    |
 | `POST /v1/messages`         | Anthropic |
 | `GET /v1/models`            | OpenAI    |
+| `GET /v1/quota`             | -         |
 
 ## Models
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "antigravity-api",
+  "name": "antigravity",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "antigravity-api",
-      "version": "0.0.1",
-      "license": "UNLICENSED",
+      "name": "antigravity",
+      "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.0.1",

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -94,7 +94,7 @@ export class AccountsService implements OnModuleInit {
     return this.accountStatesMap.size;
   }
 
-  getNextAccount(): AccountState | null {
+  getReadyAccounts(): AccountState[] {
     const now = Date.now();
 
     this.accountsList.forEach((state) => {
@@ -111,7 +111,11 @@ export class AccountsService implements OnModuleInit {
       }
     });
 
-    const readyAccounts = this.accountsList.filter((s) => s.status === 'ready');
+    return this.accountsList.filter((s) => s.status === 'ready');
+  }
+
+  getNextAccount(): AccountState | null {
+    const readyAccounts = this.getReadyAccounts();
 
     if (readyAccounts.length === 0) {
       return null;
@@ -122,6 +126,21 @@ export class AccountsService implements OnModuleInit {
     this.currentIndex = (this.currentIndex + 1) % readyAccounts.length;
 
     return selected;
+  }
+
+  getAccountById(accountId: string): AccountState | undefined {
+    return this.accountStatesMap.get(accountId);
+  }
+
+  getAllAccountIds(): string[] {
+    return Array.from(this.accountStatesMap.keys());
+  }
+
+  getAccountsForQuotaStatus(): Array<{ id: string; email: string }> {
+    return this.accountsList.map((state) => ({
+      id: state.id,
+      email: this.maskEmail(state.credential.email),
+    }));
   }
 
   markCooldown(accountId: string): void {

--- a/src/antigravity/antigravity.controller.ts
+++ b/src/antigravity/antigravity.controller.ts
@@ -78,4 +78,9 @@ export class AntigravityController {
 
     return this.antigravityService.anthropicMessages(dto, messageId);
   }
+
+  @Get('quota')
+  async getQuotaStatus() {
+    return this.antigravityService.getQuotaStatus();
+  }
 }

--- a/src/antigravity/antigravity.module.ts
+++ b/src/antigravity/antigravity.module.ts
@@ -4,9 +4,10 @@ import { AntigravityController } from './antigravity.controller';
 import { AntigravityService } from './antigravity.service';
 import { AnthropicTransformerService } from './services/anthropic-transformer.service';
 import { TransformerService } from './services/transformer.service';
+import { QuotaModule } from '../quota/quota.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, QuotaModule],
   controllers: [AntigravityController],
   providers: [
     AntigravityService,

--- a/src/antigravity/antigravity.service.spec.ts
+++ b/src/antigravity/antigravity.service.spec.ts
@@ -5,6 +5,7 @@ import { AntigravityService } from './antigravity.service';
 import { AccountsService } from '../accounts/accounts.service';
 import { TransformerService } from './services/transformer.service';
 import { AnthropicTransformerService } from './services/anthropic-transformer.service';
+import { QuotaService } from '../quota/quota.service';
 import { ChatCompletionRequestDto } from './dto';
 
 describe('AntigravityService', () => {
@@ -20,6 +21,10 @@ describe('AntigravityService', () => {
     markCooldown: jest.fn(),
     getEarliestCooldownEnd: jest.fn(),
     refreshToken: jest.fn(),
+    getAccountsForQuotaStatus: jest.fn().mockReturnValue([]),
+    getReadyAccounts: jest.fn().mockReturnValue([]),
+    getAccountById: jest.fn(),
+    getAccessToken: jest.fn(),
   };
 
   const mockTransformerService = {
@@ -36,6 +41,13 @@ describe('AntigravityService', () => {
     createStreamAccumulator: jest.fn(),
     transformStreamChunk: jest.fn(),
     createFinalEvents: jest.fn(),
+  };
+
+  const mockQuotaService = {
+    getQuotaStatus: jest
+      .fn()
+      .mockReturnValue({ totalAccounts: 0, accounts: [] }),
+    fetchQuotaFromUpstream: jest.fn(),
   };
 
   const mockConfigService = {
@@ -57,6 +69,10 @@ describe('AntigravityService', () => {
         {
           provide: AnthropicTransformerService,
           useValue: mockAnthropicTransformerService,
+        },
+        {
+          provide: QuotaService,
+          useValue: mockQuotaService,
         },
         {
           provide: ConfigService,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppService } from './app.service';
 import { AccountsModule } from './accounts/accounts.module';
 import { AntigravityModule } from './antigravity/antigravity.module';
 import { OAuthModule } from './oauth/oauth.module';
+import { QuotaModule } from './quota/quota.module';
 import configuration from './config/configuration';
 
 @Module({
@@ -16,6 +17,7 @@ import configuration from './config/configuration';
     AccountsModule,
     AntigravityModule,
     OAuthModule,
+    QuotaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/quota/index.ts
+++ b/src/quota/index.ts
@@ -1,0 +1,3 @@
+export * from './interfaces';
+export * from './quota.service';
+export * from './quota.module';

--- a/src/quota/interfaces/index.ts
+++ b/src/quota/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './quota.interface';

--- a/src/quota/interfaces/quota.interface.ts
+++ b/src/quota/interfaces/quota.interface.ts
@@ -1,0 +1,39 @@
+export interface QuotaInfo {
+  remainingFraction: number;
+  resetTime?: string;
+}
+
+export interface QuotaCacheEntry {
+  quota: number;
+  resetTime?: Date;
+  lastFetchedAt: Date;
+}
+
+export interface FetchAvailableModelsResponse {
+  models: Record<
+    string,
+    {
+      quotaInfo?: QuotaInfo;
+      [key: string]: unknown;
+    }
+  >;
+}
+
+export interface QuotaStatusResponse {
+  totalAccounts: number;
+  accounts: AccountQuotaStatus[];
+}
+
+export interface AccountQuotaStatus {
+  accountId: string;
+  email: string;
+  models: ModelQuotaStatus[];
+  lastFetchedAt?: string;
+}
+
+export interface ModelQuotaStatus {
+  modelName: string;
+  quota: number;
+  resetTime?: string;
+  status: 'available' | 'exhausted' | 'unknown';
+}

--- a/src/quota/quota.module.ts
+++ b/src/quota/quota.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { QuotaService } from './quota.service';
+
+@Module({
+  providers: [QuotaService],
+  exports: [QuotaService],
+})
+export class QuotaModule {}

--- a/src/quota/quota.service.spec.ts
+++ b/src/quota/quota.service.spec.ts
@@ -1,0 +1,244 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { QuotaService } from './quota.service';
+import { AccountState } from '../accounts/interfaces';
+
+jest.mock('axios');
+import axios from 'axios';
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('QuotaService', () => {
+  let service: QuotaService;
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue(0.01),
+  };
+
+  const createMockAccountState = (id: string, email: string): AccountState => ({
+    id,
+    credential: {
+      email,
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiryDate: Date.now() + 3600000,
+    },
+    status: 'ready',
+    requestCount: 0,
+    errorCount: 0,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuotaService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<QuotaService>(QuotaService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('fetchQuotaFromUpstream', () => {
+    const mockAccountState = createMockAccountState(
+      'account-1',
+      'test@example.com',
+    );
+
+    it('should fetch and cache quota from upstream', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          models: {
+            'gemini-2.5-pro': {
+              quotaInfo: {
+                remainingFraction: 0.85,
+                resetTime: '2025-12-17T00:00:00Z',
+              },
+            },
+            'gemini-2.0-flash': {
+              quotaInfo: {
+                remainingFraction: 1.0,
+              },
+            },
+          },
+        },
+      });
+
+      await service.fetchQuotaFromUpstream(
+        mockAccountState,
+        'access-token',
+        'project-id',
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'test@example.com' },
+      ]);
+
+      expect(status.totalAccounts).toBe(1);
+      expect(status.accounts[0].models).toHaveLength(2);
+
+      const proModel = status.accounts[0].models.find(
+        (m) => m.modelName === 'gemini-2.5-pro',
+      );
+      expect(proModel?.quota).toBe(0.85);
+      expect(proModel?.status).toBe('available');
+    });
+
+    it('should try next URL on failure', async () => {
+      mockedAxios.post
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          data: {
+            models: {
+              'gemini-2.0-flash': {
+                quotaInfo: { remainingFraction: 0.5 },
+              },
+            },
+          },
+        });
+
+      await service.fetchQuotaFromUpstream(
+        mockAccountState,
+        'access-token',
+        'project-id',
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'test@example.com' },
+      ]);
+      expect(status.accounts[0].models).toHaveLength(1);
+    });
+
+    it('should handle all URLs failing gracefully', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+
+      await service.fetchQuotaFromUpstream(
+        mockAccountState,
+        'access-token',
+        'project-id',
+      );
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'test@example.com' },
+      ]);
+      expect(status.accounts[0].models).toHaveLength(0);
+    });
+  });
+
+  describe('getQuotaStatus', () => {
+    it('should return empty models for accounts without cache', () => {
+      const status = service.getQuotaStatus([
+        { id: 'unknown-account', email: 'unknown@example.com' },
+      ]);
+
+      expect(status.totalAccounts).toBe(1);
+      expect(status.accounts[0].accountId).toBe('unknown-account');
+      expect(status.accounts[0].models).toHaveLength(0);
+      expect(status.accounts[0].lastFetchedAt).toBeUndefined();
+    });
+
+    it('should return correct status based on quota threshold', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          models: {
+            'model-available': {
+              quotaInfo: { remainingFraction: 0.5 },
+            },
+            'model-exhausted': {
+              quotaInfo: { remainingFraction: 0.005 },
+            },
+          },
+        },
+      });
+
+      await service.fetchQuotaFromUpstream(
+        createMockAccountState('account-1', 'test@example.com'),
+        'access-token',
+      );
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'test@example.com' },
+      ]);
+
+      const available = status.accounts[0].models.find(
+        (m) => m.modelName === 'model-available',
+      );
+      const exhausted = status.accounts[0].models.find(
+        (m) => m.modelName === 'model-exhausted',
+      );
+
+      expect(available?.status).toBe('available');
+      expect(exhausted?.status).toBe('exhausted');
+    });
+
+    it('should sort models alphabetically', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          models: {
+            'z-model': { quotaInfo: { remainingFraction: 1.0 } },
+            'a-model': { quotaInfo: { remainingFraction: 1.0 } },
+            'm-model': { quotaInfo: { remainingFraction: 1.0 } },
+          },
+        },
+      });
+
+      await service.fetchQuotaFromUpstream(
+        createMockAccountState('account-1', 'test@example.com'),
+        'access-token',
+      );
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'test@example.com' },
+      ]);
+
+      expect(status.accounts[0].models.map((m) => m.modelName)).toEqual([
+        'a-model',
+        'm-model',
+        'z-model',
+      ]);
+    });
+
+    it('should handle multiple accounts', async () => {
+      mockedAxios.post.mockResolvedValue({
+        data: {
+          models: {
+            'gemini-2.0-flash': { quotaInfo: { remainingFraction: 0.75 } },
+          },
+        },
+      });
+
+      await service.fetchQuotaFromUpstream(
+        createMockAccountState('account-1', 'user1@example.com'),
+        'access-token',
+      );
+
+      await service.fetchQuotaFromUpstream(
+        createMockAccountState('account-2', 'user2@example.com'),
+        'access-token',
+      );
+
+      const status = service.getQuotaStatus([
+        { id: 'account-1', email: 'user1@example.com' },
+        { id: 'account-2', email: 'user2@example.com' },
+      ]);
+
+      expect(status.totalAccounts).toBe(2);
+      expect(status.accounts).toHaveLength(2);
+      expect(status.accounts[0].models).toHaveLength(1);
+      expect(status.accounts[1].models).toHaveLength(1);
+    });
+  });
+});

--- a/src/quota/quota.service.ts
+++ b/src/quota/quota.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import {
+  QuotaCacheEntry,
+  FetchAvailableModelsResponse,
+  QuotaStatusResponse,
+  AccountQuotaStatus,
+  ModelQuotaStatus,
+} from './interfaces';
+import { AccountState } from '../accounts/interfaces';
+import { BASE_URLS, USER_AGENT } from '../antigravity/constants';
+
+@Injectable()
+export class QuotaService {
+  private readonly logger = new Logger(QuotaService.name);
+  private readonly quotaCache = new Map<string, Map<string, QuotaCacheEntry>>();
+  private readonly quotaThreshold: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.quotaThreshold = this.configService.get<number>(
+      'QUOTA_THRESHOLD',
+      0.01,
+    );
+  }
+
+  async fetchQuotaFromUpstream(
+    accountState: AccountState,
+    accessToken: string,
+    projectId?: string,
+  ): Promise<void> {
+    const endpoint = ':fetchAvailableModels';
+
+    for (const baseUrl of BASE_URLS) {
+      const url = `${baseUrl}/v1internal${endpoint}`;
+
+      try {
+        this.logger.debug(
+          `Fetching quota from ${url} for account ${accountState.id}`,
+        );
+
+        const response = await axios.post<FetchAvailableModelsResponse>(
+          url,
+          { project: projectId || '' },
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'Content-Type': 'application/json',
+              'User-Agent': USER_AGENT,
+            },
+            timeout: 30000,
+          },
+        );
+
+        if (response.data?.models) {
+          this.updateQuotasFromModels(accountState.id, response.data.models);
+          this.logger.log(
+            `Updated quotas for account ${accountState.id}: ${Object.keys(response.data.models).length} models`,
+          );
+          return;
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        this.logger.warn(
+          `Failed to fetch quota from ${baseUrl}: ${errorMessage}`,
+        );
+        continue;
+      }
+    }
+
+    this.logger.error(
+      `Failed to fetch quota from all endpoints for account ${accountState.id}`,
+    );
+  }
+
+  private updateQuotasFromModels(
+    accountId: string,
+    models: FetchAvailableModelsResponse['models'],
+  ): void {
+    let accountCache = this.quotaCache.get(accountId);
+    if (!accountCache) {
+      accountCache = new Map();
+      this.quotaCache.set(accountId, accountCache);
+    }
+
+    for (const [modelName, modelInfo] of Object.entries(models)) {
+      if (modelInfo.quotaInfo) {
+        const quota = modelInfo.quotaInfo.remainingFraction ?? 1.0;
+        const resetTime = modelInfo.quotaInfo.resetTime
+          ? new Date(modelInfo.quotaInfo.resetTime)
+          : undefined;
+
+        accountCache.set(modelName, {
+          quota,
+          resetTime,
+          lastFetchedAt: new Date(),
+        });
+
+        this.logger.debug(
+          `Quota updated: account=${accountId}, model=${modelName}, quota=${quota.toFixed(4)}`,
+        );
+      }
+    }
+  }
+
+  getQuotaStatus(
+    accounts: Array<{ id: string; email: string }>,
+  ): QuotaStatusResponse {
+    const accountStatuses: AccountQuotaStatus[] = accounts.map((account) => {
+      const accountCache = this.quotaCache.get(account.id);
+      const models: ModelQuotaStatus[] = [];
+
+      if (accountCache) {
+        for (const [modelName, entry] of accountCache.entries()) {
+          models.push({
+            modelName,
+            quota: entry.quota,
+            resetTime: entry.resetTime?.toISOString(),
+            status:
+              entry.quota > this.quotaThreshold ? 'available' : 'exhausted',
+          });
+        }
+      }
+
+      const lastFetched =
+        accountCache && accountCache.size > 0
+          ? Array.from(accountCache.values()).reduce(
+              (latest, entry) =>
+                entry.lastFetchedAt > latest ? entry.lastFetchedAt : latest,
+              new Date(0),
+            )
+          : undefined;
+
+      return {
+        accountId: account.id,
+        email: account.email,
+        models: models.sort((a, b) => a.modelName.localeCompare(b.modelName)),
+        lastFetchedAt: lastFetched?.toISOString(),
+      };
+    });
+
+    return {
+      totalAccounts: accounts.length,
+      accounts: accountStatuses,
+    };
+  }
+}

--- a/src/quota/quota.service.ts
+++ b/src/quota/quota.service.ts
@@ -32,7 +32,7 @@ export class QuotaService {
     const endpoint = ':fetchAvailableModels';
 
     for (const baseUrl of BASE_URLS) {
-      const url = `${baseUrl}/v1internal${endpoint}`;
+      const url = `${baseUrl}${endpoint}`;
 
       try {
         this.logger.debug(


### PR DESCRIPTION
## Summary
- Add quota module to track and monitor model usage quotas per account
- Expose `/quota` endpoint for checking real-time quota status across all accounts