### PR TITLE
refactor: simplify thinking model routing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Visit `http://localhost:3000/oauth/authorize` to authenticate with Google.
 
 - `gemini-3-pro-preview`
 - `claude-sonnet-4-5`
-- `claude-sonnet-4-5-thinking`
 - `claude-opus-4-5`
 
-_as of 9-12-2025_
+_as of 16-12-2025_
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ Visit `http://localhost:3000/oauth/authorize` to authenticate with Google.
 
 _as of 16-12-2025_
 
+## Reasoning/Thinking Mode
+
+Enable reasoning mode by setting `reasoning_effort` in your request:
+
+```json
+{
+  "model": "claude-sonnet-4-5",
+  "messages": [...],
+  "reasoning_effort": "low",
+  "stream": true
+}
+```
+
+**Values**: `low`, `medium`, `high`
+
+**Model behavior**:
+
+- `gemini-3-pro-preview`: Uses `thinkingLevel` (low/high)
+- `claude-sonnet-4-5`: Uses `thinkingBudget` (8192/16384/32768 tokens)
+- `claude-opus-4-5`: Always uses thinking mode (parameter optional)
+
+**Known limitation**: Claude models only return `reasoning_content` in streaming mode. Non-streaming requests will process thinking internally but won't return it in the response.
+
 ## License
 
 MIT

--- a/src/antigravity/constants/models.constant.ts
+++ b/src/antigravity/constants/models.constant.ts
@@ -1,7 +1,6 @@
 export const AVAILABLE_MODELS = [
   'gemini-3-pro-preview',
   'claude-sonnet-4-5',
-  'claude-sonnet-4-5-thinking',
   'claude-opus-4-5',
 ] as const;
 
@@ -9,11 +8,7 @@ export type AvailableModel = (typeof AVAILABLE_MODELS)[number];
 
 export const THINKING_ONLY_MODELS = ['claude-opus-4-5'] as const;
 
-export const MODEL_ALIAS_MAP: Record<string, string> = {
-  'gemini-3-pro-low': 'gemini-3-pro-preview',
-  'gemini-3-pro-high': 'gemini-3-pro-preview',
-  'claude-opus-4-5': 'claude-opus-4-5-thinking',
-};
+export const MODEL_ALIAS_MAP: Record<string, string> = {};
 
 export const THINKING_LEVEL_MODELS = ['gemini-3-pro-preview'];
 
@@ -26,13 +21,11 @@ export const THINKING_BUDGETS: Record<string, number> = {
 export const DEFAULT_MAX_TOKENS: Record<string, number> = {
   'claude-opus-4-5': 64000,
   'claude-sonnet-4-5': 64000,
-  'claude-sonnet-4-5-thinking': 64000,
   'gemini-3-pro-preview': 65536,
 };
 
 export const MODEL_OWNERS: Record<string, string> = {
   'gemini-3-pro-preview': 'google',
   'claude-sonnet-4-5': 'anthropic',
-  'claude-sonnet-4-5-thinking': 'anthropic',
   'claude-opus-4-5': 'anthropic',
 };

--- a/src/antigravity/services/anthropic-transformer.service.ts
+++ b/src/antigravity/services/anthropic-transformer.service.ts
@@ -89,7 +89,7 @@ export class AnthropicTransformerService {
     const isThinking = thinking?.type === 'enabled';
 
     if (model === 'claude-opus-4-5') {
-      return isThinking ? 'claude-opus-4-5-thinking' : 'claude-opus-4-5';
+      return 'claude-opus-4-5-thinking';
     }
 
     if (model === 'claude-sonnet-4-5') {

--- a/src/antigravity/services/anthropic-transformer.service.ts
+++ b/src/antigravity/services/anthropic-transformer.service.ts
@@ -86,12 +86,14 @@ export class AnthropicTransformerService {
     model: string,
     thinking?: { type: 'enabled' | 'disabled'; budget_tokens?: number },
   ): string {
+    const isThinking = thinking?.type === 'enabled';
+
     if (model === 'claude-opus-4-5') {
-      return 'claude-opus-4-5-thinking';
+      return isThinking ? 'claude-opus-4-5-thinking' : 'claude-opus-4-5';
     }
 
-    if (model === 'claude-sonnet-4-5' && thinking?.type === 'enabled') {
-      return 'claude-sonnet-4-5-thinking';
+    if (model === 'claude-sonnet-4-5') {
+      return isThinking ? 'claude-sonnet-4-5-thinking' : 'claude-sonnet-4-5';
     }
 
     return MODEL_ALIAS_MAP[model] || model;

--- a/src/antigravity/services/anthropic-transformer.service.ts
+++ b/src/antigravity/services/anthropic-transformer.service.ts
@@ -222,9 +222,10 @@ export class AnthropicTransformerService {
     if (dto.max_tokens) config.maxOutputTokens = dto.max_tokens;
     if (dto.stop_sequences?.length) config.stopSequences = dto.stop_sequences;
 
-    if (dto.thinking?.type === 'enabled') {
+    const isOpus = dto.model === 'claude-opus-4-5';
+    if (dto.thinking?.type === 'enabled' || isOpus) {
       config.thinkingConfig = {
-        thinkingBudget: dto.thinking.budget_tokens || 16384,
+        thinkingBudget: dto.thinking?.budget_tokens || 16384,
         include_thoughts: true,
       };
     }

--- a/src/antigravity/services/transformer.service.ts
+++ b/src/antigravity/services/transformer.service.ts
@@ -86,18 +86,20 @@ export class TransformerService {
 
   private getInternalModel(model: string, reasoningEffort?: string): string {
     if (model === 'gemini-3-pro-preview' || model.startsWith('gemini-3-pro')) {
-      if (reasoningEffort === 'low' || model === 'gemini-3-pro-low') {
-        return 'gemini-3-pro-low';
+      if (reasoningEffort === 'medium' || reasoningEffort === 'high') {
+        return 'gemini-3-pro-high';
       }
-      return 'gemini-3-pro-high';
+      return 'gemini-3-pro-low';
     }
 
     if (model === 'claude-opus-4-5') {
-      return 'claude-opus-4-5-thinking';
+      return reasoningEffort ? 'claude-opus-4-5-thinking' : 'claude-opus-4-5';
     }
 
-    if (model === 'claude-sonnet-4-5' && reasoningEffort) {
-      return 'claude-sonnet-4-5-thinking';
+    if (model === 'claude-sonnet-4-5') {
+      return reasoningEffort
+        ? 'claude-sonnet-4-5-thinking'
+        : 'claude-sonnet-4-5';
     }
 
     return MODEL_ALIAS_MAP[model] || model;
@@ -228,11 +230,8 @@ export class TransformerService {
 
     if (dto.stop) config.stopSequences = dto.stop;
 
-    if (isGemini3) {
-      const level =
-        dto.reasoning_effort === 'low' || dto.model.includes('-low')
-          ? 'low'
-          : 'high';
+    if (isGemini3 && dto.reasoning_effort) {
+      const level = dto.reasoning_effort === 'low' ? 'low' : 'high';
       config.thinkingConfig = {
         thinkingLevel: level,
         include_thoughts: true,

--- a/src/antigravity/services/transformer.service.ts
+++ b/src/antigravity/services/transformer.service.ts
@@ -93,7 +93,7 @@ export class TransformerService {
     }
 
     if (model === 'claude-opus-4-5') {
-      return reasoningEffort ? 'claude-opus-4-5-thinking' : 'claude-opus-4-5';
+      return 'claude-opus-4-5-thinking';
     }
 
     if (model === 'claude-sonnet-4-5') {

--- a/src/antigravity/services/transformer.service.ts
+++ b/src/antigravity/services/transformer.service.ts
@@ -237,7 +237,8 @@ export class TransformerService {
         include_thoughts: true,
       };
     } else if (isClaude || dto.model.includes('gemini-2.5')) {
-      if (dto.reasoning_effort || dto.model.includes('thinking')) {
+      const isOpus = dto.model === 'claude-opus-4-5';
+      if (dto.reasoning_effort || isOpus) {
         const budget = dto.reasoning_effort
           ? THINKING_BUDGETS[dto.reasoning_effort]
           : -1;


### PR DESCRIPTION
## Summary
- Simplify thinking model routing by determining model variant at request time based on reasoning effort/thinking config rather than using static aliases
- Default Gemini 3 Pro to low thinking level instead of high when no reasoning effort specified