### PR TITLE
chore(api): increase body parser limit to support Gemini 3 Flash 1M t…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,17 @@ import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
 import { AccountsService } from './accounts/accounts.service';
 import { OpenAIExceptionFilter } from './common/filters/openai-exception.filter';
+import { json, urlencoded } from 'express';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
-  const app = await NestFactory.create(AppModule);
+
+  // Disable default bodyParser to allow custom configuration below
+  const app = await NestFactory.create(AppModule, { bodyParser: false });
+
+  // Increase payload limit to 50mb to allow large text inputs
+  app.use(json({ limit: '50mb' }));
+  app.use(urlencoded({ extended: true, limit: '50mb' }));
 
   app.useGlobalFilters(new OpenAIExceptionFilter());
 


### PR DESCRIPTION
…oken context

Configure request body size limit to 50MB in antigravity/src/main.ts, allowing larger JSON payloads required for the Gemini 3 Flash model.