### PR TITLE
fix(auth): skip API key validation when PROXY_API_KEY is not set

### DIFF
--- a/src/common/guards/api-key.guard.ts
+++ b/src/common/guards/api-key.guard.ts
@@ -14,17 +14,16 @@ export class ApiKeyGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request>();
-    const isAnthropicEndpoint = request.path === '/v1/messages';
-
-    const token = isAnthropicEndpoint
-      ? this.extractAnthropicKey(request)
-      : this.extractOpenAIKey(request);
-
     const apiKey = this.configService.get<string>('proxyApiKey');
 
     if (!apiKey) {
       return true;
     }
+
+    const isAnthropicEndpoint = request.path === '/v1/messages';
+    const token = isAnthropicEndpoint
+      ? this.extractAnthropicKey(request)
+      : this.extractOpenAIKey(request);
 
     if (token !== apiKey) {
       const maskedKey =


### PR DESCRIPTION
Update api-key.guard.ts to check if proxyApiKey is set before extracting the request token. If no PROXY_API_KEY is defined, the API allows free access instead of returning an "API key missing/invalid" error.